### PR TITLE
Add core PostgreSQL schema and IRI helper functions

### DIFF
--- a/db/ddl/001_core_schema.sql
+++ b/db/ddl/001_core_schema.sql
@@ -1,0 +1,180 @@
+-- Core schema for ontology-based Korean law DB
+-- Includes extensions, lookup tables, law structures, case structures, relations, definitions, RAG chunks and logging tables
+
+-- Extensions
+create extension if not exists ltree;
+create extension if not exists pg_trgm;
+-- Optional: create extension if not exists vector; -- pgvector
+
+-- Lookup tables
+create table if not exists law_type (
+  type_code text primary key,
+  description text
+);
+
+create table if not exists relation_type (
+  rel_code text primary key,
+  priority int not null
+);
+
+-- Law tables
+create table if not exists law (
+  law_id bigserial primary key,
+  law_key text unique,
+  official_title_ko text not null,
+  official_title_en text,
+  type_code text not null references law_type(type_code),
+  created_at timestamp default now()
+);
+
+create table if not exists law_version (
+  version_id bigserial primary key,
+  law_id bigint not null references law(law_id) on delete cascade,
+  expression_date date not null,
+  lang text not null default 'ko',
+  is_consolidated boolean not null default true,
+  promulgation_date date,
+  enforcement_date date,
+  effective_from date not null,
+  effective_to date,
+  frbr_work_iri text,
+  frbr_expression_iri text unique,
+  source_id bigint,
+  checksum text,
+  unique(law_id, expression_date, lang, is_consolidated)
+);
+
+-- Article node tree
+create table if not exists article_node (
+  node_id bigserial primary key,
+  law_id bigint not null references law(law_id) on delete cascade,
+  version_id bigint not null references law_version(version_id) on delete cascade,
+  node_type text not null check (node_type in ('ARTICLE','PARAGRAPH','ITEM','SUBITEM')),
+  number_norm text,
+  title text,
+  hierarchy_path ltree not null,
+  component_iri text unique,
+  uriname text,
+  effective_from date not null,
+  effective_to date,
+  law_level text,
+  created_at timestamp default now(),
+  unique(version_id, hierarchy_path)
+);
+
+create table if not exists article_text (
+  node_id bigint primary key references article_node(node_id) on delete cascade,
+  plain_text text not null,
+  html_text text,
+  source_manifestation_id bigint,
+  updated_at timestamp default now()
+);
+create index if not exists article_text_plain_text_trgm_idx on article_text using gin (plain_text gin_trgm_ops);
+
+-- Case structures
+create table if not exists court (
+  court_slug text primary key,
+  full_name text
+);
+
+create table if not exists case_work (
+  case_id bigserial primary key,
+  court_slug text not null references court(court_slug),
+  case_no text not null,
+  title text,
+  frbr_work_iri text unique,
+  unique(court_slug, case_no)
+);
+
+create table if not exists case_expression (
+  case_expr_id bigserial primary key,
+  case_id bigint not null references case_work(case_id) on delete cascade,
+  decision_date date not null,
+  lang text not null default 'ko',
+  frbr_expression_iri text unique,
+  source_id bigint
+);
+
+create table if not exists case_paragraph (
+  para_id bigserial primary key,
+  case_expr_id bigint not null references case_expression(case_expr_id) on delete cascade,
+  para_no int not null,
+  hierarchy_path ltree not null,
+  component_iri text unique,
+  plain_text text not null,
+  html_text text
+);
+create index if not exists case_paragraph_plain_text_trgm_idx on case_paragraph using gin (plain_text gin_trgm_ops);
+
+-- Object relations
+create table if not exists object_relation (
+  rel_id bigserial primary key,
+  src_component_iri text not null,
+  dst_component_iri text not null,
+  rel_code text not null references relation_type(rel_code),
+  evidence jsonb,
+  confidence real check (confidence between 0 and 1),
+  created_at timestamp default now()
+);
+create index if not exists object_relation_rel_code_idx on object_relation (rel_code);
+create index if not exists object_relation_evidence_idx on object_relation using gin (evidence);
+create index if not exists object_relation_src_idx on object_relation (src_component_iri);
+create index if not exists object_relation_dst_idx on object_relation (dst_component_iri);
+
+-- Term definitions
+create table if not exists term_definition (
+  term_id bigserial primary key,
+  law_id bigint not null references law(law_id) on delete cascade,
+  version_id bigint not null references law_version(version_id) on delete cascade,
+  term_text text not null,
+  defining_component_iri text not null,
+  definition_text text not null,
+  created_at timestamp default now(),
+  unique(version_id, term_text)
+);
+create index if not exists term_definition_term_text_trgm_idx on term_definition using gin (term_text gin_trgm_ops);
+
+-- RAG chunks
+create table if not exists rag_chunk (
+  chunk_id bigserial primary key,
+  component_iri text not null,
+  chunk_type text not null check (chunk_type in ('ARTICLE','PARAGRAPH','ITEM','CASE_PARA')),
+  text text not null,
+  law_id bigint,
+  version_id bigint,
+  law_level text,
+  effective_from date,
+  effective_to date,
+  point_in_time date
+  -- Optional embedding column can be added with pgvector
+);
+create index if not exists rag_chunk_text_trgm_idx on rag_chunk using gin (text gin_trgm_ops);
+
+-- Source and logs
+create table if not exists source (
+  source_id bigserial primary key,
+  provider text not null,
+  url text,
+  snapshot_hash text,
+  fetched_at timestamp default now(),
+  license text
+);
+
+create table if not exists import_log (
+  import_id bigserial primary key,
+  source_id bigint references source(source_id),
+  target_table text not null,
+  rowcount int,
+  started_at timestamp default now(),
+  finished_at timestamp
+);
+
+create table if not exists validation_issue (
+  issue_id bigserial primary key,
+  severity text check (severity in ('ERROR','WARN','INFO')),
+  category text,
+  target_iri text,
+  detail jsonb,
+  created_at timestamp default now()
+);
+

--- a/db/functions/iri_functions.sql
+++ b/db/functions/iri_functions.sql
@@ -1,0 +1,30 @@
+-- Functions for generating IRIs and normalizing Korean references
+
+create or replace function make_law_expr_iri(p_type text, p_key text, p_date date, p_lang text default 'ko')
+returns text language sql immutable as $$
+  select format('/akn/kr/%s/%s/expr/%s~%s', p_type, p_key, to_char(p_date,'YYYY-MM-DD'), p_lang);
+$$;
+
+create or replace function make_component_iri(p_expr_iri text, p_article text, p_par text, p_item text)
+returns text language sql immutable as $$
+  select p_expr_iri
+    || case when p_article is not null then '/art-'||p_article else '' end
+    || case when p_par     is not null then '/par-'||p_par     else '' end
+    || case when p_item    is not null then '/item-'||p_item   else '' end;
+$$;
+
+create or replace function normalize_korean_ref(p_text text)
+returns jsonb language plpgsql immutable as $$
+declare art text; par text; itm text;
+begin
+  art := regexp_replace(p_text, '.*제([0-9]+)조(?:의([0-9]+))?.*', '\1-\2');
+  art := replace(art, '-', '-');
+  if art like '%-\\%' then art := replace(art, '-null', ''); end if;
+
+  par := (regexp_matches(p_text, '제([0-9]+)항'))[1];
+  itm := (regexp_matches(p_text, '제([0-9]+)호'))[1];
+
+  return jsonb_build_object('article', nullif(art,''),
+                            'paragraph', par,
+                            'item', itm);
+end $$;

--- a/db/seeds/lookup_seeds.sql
+++ b/db/seeds/lookup_seeds.sql
@@ -1,0 +1,17 @@
+-- Seed data for lookup tables and example law
+
+insert into law_type(type_code, description) values
+('act','국회 제정 법률') on conflict do nothing;
+
+insert into relation_type(rel_code, priority) values
+('SPECIAL_RULE_OF',10),('AMENDS',20),('BASED_ON',30),('APPLIES_TO',40),('CITES',50),('REFERS_TO',60)
+on conflict do nothing;
+
+insert into law(law_key, official_title_ko, type_code)
+values ('pipa','개인정보 보호법','act')
+on conflict do nothing;
+
+insert into law_version(law_id, expression_date, is_consolidated, effective_from, lang, frbr_expression_iri)
+select law_id, date '2024-11-30', true, date '2024-11-30', 'ko',
+       make_law_expr_iri('act','pipa','2024-11-30'::date,'ko')
+from law where law_key='pipa';


### PR DESCRIPTION
## Summary
- add PostgreSQL schema for laws, cases, relations, term definitions, and RAG chunks
- include helper functions for generating FRBR IRIs and normalizing Korean references
- seed lookup tables with law types, relation types, and example law data

## Testing
- `npm test` *(fails: Cannot find module 'supertest'; Jest cannot parse ES modules)*

------
https://chatgpt.com/codex/tasks/task_e_689cadde6f2c832da2d44d7668a8f6ea